### PR TITLE
Adiciona Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Ignora a pasta de build do Swift
+.build
+
+# Ignora arquivos do Git e Xcode
+.git
+.swiftpm
+*.xcodeproj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# --- ESTÁGIO 1: Builder ---
+FROM swift:6.0-jammy AS builder
+
+# Define o diretório de trabalho dentro do contêiner
+WORKDIR /app
+
+# Copia os arquivos de manifesto primeiro para aproveitar o cache do Docker.
+# O build só será refeito se esses arquivos mudarem.
+COPY Package.swift Package.resolved ./
+
+# Resolve as dependências do projeto
+RUN swift package resolve
+
+# Copia todo o resto do código-fonte
+COPY . .
+
+# Compila o projeto em modo "release" para otimização e performance.
+# O executável será criado em .build/release/
+RUN swift build -c release
+
+# --- ESTÁGIO 2: Runner ---
+# Começamos com uma imagem base limpa e leve do Ubuntu.
+FROM ubuntu:22.04
+
+# Define o diretório de trabalho
+WORKDIR /app
+
+# Instala as dependências de runtime do Swift.
+# Isso garante que todas as bibliotecas .so necessárias estejam presentes.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libatomic1 \
+    libcurl4 \
+    libxml2 \
+    libicu70 \
+    libssl3 && \
+    rm -rf /var/lib/apt/lists
+
+# Copia as bibliotecas de runtime do Swift do estágio de build.
+# Isso é mais confiável do que instalá-las separadamente.
+COPY --from=builder /usr/lib/swift/linux/*.so* /usr/lib/swift/linux/
+
+# --- Ponto crucial: Copia APENAS o binário compilado do estágio builder ---
+# Substitua "NomeDoSeuExecutavel" pelo nome do seu target executável
+# Você pode encontrar esse nome no seu arquivo Package.swift, na seção `executableTarget(name: "...")`
+COPY --from=builder /app/.build/release/FST .
+
+# Define o comando que será executado quando o contêiner iniciar.
+# O contêiner se comportará exatamente como o seu executável.
+ENTRYPOINT ["./FST"]
+
+# (Opcional) Define um comando padrão, como mostrar a ajuda.
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     libatomic1 \
     libcurl4 \
     libxml2 \
-    libicu70 \
+    libicu-dev libicu70 \
     libssl3 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This pull request introduces Docker support for building and running the Swift CLI project. The main changes include the addition of a `.dockerignore` file to optimize the Docker build process and a new multi-stage `Dockerfile` for compiling and packaging the executable in a minimal runtime environment.

**Docker support and optimization:**

* Added `.dockerignore` file to exclude build artifacts, Git metadata, Swift package manager files, and Xcode project files from the Docker context, reducing build size and improving performance.
* Created a multi-stage `Dockerfile` that builds the Swift CLI in a dedicated build environment, then packages only the necessary runtime files and the compiled binary into a minimal Ubuntu image for efficient deployment.